### PR TITLE
Fix version grep in CI workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Increment version
         run: |
           file="forwarder.user.js"
-          version=$(grep -oP '(?<=@version\s+)[0-9]+\.[0-9]+\.[0-9]+' "$file")
+          version=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "$file" | head -n1)
           IFS='.' read -r major minor patch <<< "$version"
           patch=$((patch+1))
           new_version="$major.$minor.$patch"
@@ -30,6 +30,6 @@ jobs:
             echo "No changes to commit"
             exit 0
           fi
-          version=$(grep -oP '(?<=@version\s+)[0-9]+\.[0-9]+\.[0-9]+' forwarder.user.js)
+          version=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' forwarder.user.js | head -n1)
           git commit -m "ci: bump version to $version"
           git push


### PR DESCRIPTION
## Summary
- fix the version parsing in `bump.yml` to avoid using grep lookbehind

## Testing
- `grep -n "@version" -n forwarder.user.js`
- Manual shell test of the version bump logic

------
https://chatgpt.com/codex/tasks/task_e_68461c949824832e889389aa174896e6