### PR TITLE
Add automatic forwarding with cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository hosts a Violent Monkey userscript that forwards project data fro
    ```
 3. Violent Monkey will automatically check this URL for updates when the `@version` changes.
 
-The script adds a button to the Adekosiparis site that fetches projects and sends them to Vertigram.
+The script automatically forwards projects to Vertigram whenever you visit the Adekosiparis site. It stores a timestamp in a cookie so forwarding happens at most once every 30 minutes. A small status bar appears at the top of the page while the request is in progress.
 
 ## Automatic version bump
 

--- a/forwarder.user.js
+++ b/forwarder.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         Adekosiparis → Vertigram Forwarder
 // @namespace    https://github.com/akina5525/adekoforwarder
-// @version      1.0.3
-// @description  Adds a button to forward projects to Vertigram API
+// @version      1.0.4
+// @description  Automatically forwards projects to Vertigram API every 30 minutes
 // @match        https://adekosiparis.vanucci.com/*
 // @updateURL    https://raw.githubusercontent.com/akina5525/adekoforwarder/main/forwarder.user.js
 // @downloadURL  https://raw.githubusercontent.com/akina5525/adekoforwarder/main/forwarder.user.js
@@ -12,23 +12,50 @@
 (function() {
     'use strict';
 
-    // Create the button
-    const btn = document.createElement('button');
-    btn.textContent = 'Forward Projects';
-    Object.assign(btn.style, {
-        padding: '10px 15px',
-        backgroundColor: 'orange',
-        color: '#fff',
-        border: 'none',
-        borderRadius: '5px',
-        cursor: 'pointer',
-        marginRight: '10px'
-    });
+    // Utility to get a cookie by name
+    function getCookie(name) {
+        const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+        return match ? decodeURIComponent(match[1]) : null;
+    }
 
-    // Click handler
-    btn.addEventListener('click', async () => {
-        btn.disabled = true;
-        btn.textContent = 'Sending…';
+    // Utility to set a cookie with path=/
+    function setCookie(name, value, maxAgeSeconds) {
+        document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${maxAgeSeconds}`;
+    }
+
+    // Shows a small top bar with the given message
+    function showBar(msg) {
+        let bar = document.getElementById('forwarder-status-bar');
+        if (!bar) {
+            bar = document.createElement('div');
+            bar.id = 'forwarder-status-bar';
+            Object.assign(bar.style, {
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                right: 0,
+                padding: '10px',
+                backgroundColor: '#ffb700',
+                color: '#000',
+                textAlign: 'center',
+                zIndex: 10000,
+                fontSize: '14px'
+            });
+            document.body.appendChild(bar);
+        }
+        bar.textContent = msg;
+    }
+
+    // Hide the bar after 3 seconds
+    function hideBar() {
+        const bar = document.getElementById('forwarder-status-bar');
+        if (bar) {
+            setTimeout(() => bar.remove(), 3000);
+        }
+    }
+
+    async function forward() {
+        showBar('Forwarding projects…');
         try {
             const res1 = await fetch('https://adekosiparis.vanucci.com/Project/GetProjects?page=1&limit=50');
             if (!res1.ok) throw new Error(`Fetch projects failed: ${res1.status}`);
@@ -39,24 +66,24 @@
                 body: JSON.stringify(data)
             });
             if (!res2.ok) throw new Error(`POST failed: ${res2.status}`);
-            alert('✅ Projects forwarded successfully!');
+            showBar('✅ Projects forwarded successfully');
+            setCookie('last_forward', Date.now().toString(), 60 * 60 * 24 * 30);
         } catch (err) {
             console.error(err);
-            alert('❌ Error: ' + err.message);
+            showBar('❌ Error: ' + err.message);
         } finally {
-            btn.disabled = false;
-            btn.textContent = 'Forward Projects';
+            hideBar();
         }
-    });
-
-    // Insert before "Yeni Proje Ekle" button if found
-    const reference = Array.from(document.querySelectorAll('button')).find(
-        el => el.textContent.trim() === 'Yeni Proje Ekle'
-    );
-    if (reference && reference.parentNode) {
-        reference.parentNode.insertBefore(btn, reference);
-    } else {
-        //document.body.appendChild(btn);
     }
+
+    function maybeForward() {
+        const last = parseInt(getCookie('last_forward') || '0', 10);
+        if (Date.now() - last > 30 * 60 * 1000) {
+            forward();
+        }
+    }
+
+    // Run on page load
+    maybeForward();
 })();
 


### PR DESCRIPTION
## Summary
- automatically forward to Vertigram every 30 minutes
- show a status bar while forwarding and hide after completion
- remove mention of the old button from README

## Testing
- `node -c forwarder.user.js`

------
https://chatgpt.com/codex/tasks/task_e_684735f080fc832e92a0cfee81bec837