### PR TITLE
Implement basic scheduler

### DIFF
--- a/scheduler.js
+++ b/scheduler.js
@@ -1,0 +1,31 @@
+function scheduleJob(startDate, durationDays) {
+  if (typeof startDate === 'string') {
+    startDate = new Date(startDate);
+  } else if (startDate instanceof Date) {
+    startDate = new Date(startDate.getTime());
+  } else {
+    throw new Error('Invalid start date');
+  }
+  if (isNaN(startDate)) {
+    throw new Error('Invalid start date');
+  }
+  if (durationDays <= 0) {
+    return [];
+  }
+  const result = [];
+  while (result.length < durationDays) {
+    const day = startDate.getDay(); // 0=Sun
+    if (day !== 0) {
+      result.push(startDate.toISOString().slice(0, 10));
+    }
+    startDate.setDate(startDate.getDate() + 1);
+  }
+  return result;
+}
+
+if (require.main === module) {
+  const [start, days] = process.argv.slice(2);
+  console.log(scheduleJob(start, parseInt(days, 10)));
+}
+
+module.exports = { scheduleJob };

--- a/scheduler.test.js
+++ b/scheduler.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { scheduleJob } = require('./scheduler');
+
+// start on Saturday for 2-day job
+assert.deepStrictEqual(
+  scheduleJob('2023-04-15', 2),
+  ['2023-04-15', '2023-04-17']
+);
+
+// start on Monday for 3-day job
+assert.deepStrictEqual(
+  scheduleJob('2023-04-17', 3),
+  ['2023-04-17', '2023-04-18', '2023-04-19']
+);
+
+// start on Sunday for 2-day job
+assert.deepStrictEqual(
+  scheduleJob('2023-04-16', 2),
+  ['2023-04-17', '2023-04-18']
+);
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add scheduler.js to compute work days and skip Sundays
- include scheduler.test.js to cover edge cases

## Testing
- `node scheduler.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68473c63d4a0832e9314ecc1dcaa1d76