### PR TITLE
Implement login page guard

### DIFF
--- a/forwarder.user.js
+++ b/forwarder.user.js
@@ -12,6 +12,11 @@
 (function() {
     'use strict';
 
+    // Exit early on the login page
+    if (location.href.toLowerCase().includes('account/login')) {
+        return;
+    }
+
     // Utility to get a cookie by name
     function getCookie(name) {
         const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));


### PR DESCRIPTION
## Summary
- stop script execution on pages that contain `account/login`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6847516dd794832eaf870559d351ab3f