### PR TITLE
Support parasut invoice page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adekosiparis → Vertigram Forwarder
 
-This repository hosts a Violent Monkey userscript that forwards project data from Adekosiparis to the Vertigram API.
+This repository hosts a Violent Monkey userscript that forwards project data from Adekosiparis (and select Parasut pages) to the Vertigram API.
 
 ## Installation
 
@@ -11,7 +11,7 @@ This repository hosts a Violent Monkey userscript that forwards project data fro
    ```
 3. Violent Monkey will automatically check this URL for updates when the `@version` changes.
 
-The script automatically forwards projects to Vertigram whenever you visit the Adekosiparis site. It stores a timestamp in a cookie so forwarding happens at most once every 30 minutes. A small status bar appears at the top of the page while the request is in progress.
+The script automatically forwards projects to Vertigram whenever you visit the Adekosiparis site or the Parasut invoice creation page. It stores a timestamp in a cookie so forwarding happens at most once every 30 minutes. A small status bar appears at the top of the page while the request is in progress.
 
 ## Automatic version bump
 

--- a/forwarder.user.js
+++ b/forwarder.user.js
@@ -4,6 +4,7 @@
 // @version      1.0.11
 // @description  Automatically forwards projects to Vertigram API every 30 minutes
 // @match        https://adekosiparis.vanucci.com/*
+// @match        https://uygulama.parasut.com/*/satislar/yeni/fatura
 // @updateURL    https://raw.githubusercontent.com/akina5525/adekoforwarder/main/forwarder.user.js
 // @downloadURL  https://raw.githubusercontent.com/akina5525/adekoforwarder/main/forwarder.user.js
 // @grant        none
@@ -101,8 +102,24 @@
         }
     }
 
+    // Automatically expand the order-info section on Parasut invoice pages
+    function clickParasutOrderInfo() {
+        if (!location.hostname.includes('uygulama.parasut.com')) {
+            return;
+        }
+        setTimeout(() => {
+            const orderDiv = document.querySelector("div[class*='order-info']");
+            if (!orderDiv) {
+                return;
+            }
+            const clickable = orderDiv.querySelector('a, button, [role="button"], input[type="button"], input[type="submit"]');
+            (clickable || orderDiv).click();
+        }, 500);
+    }
+
     // Run on page load
     maybeForward();
     attachLogoutHandler();
+    clickParasutOrderInfo();
 })();
 


### PR DESCRIPTION
## Summary
- add URL pattern for invoice creation page on uygulama.parasut.com
- auto-click div with `order-info` class when present
- clarify auto-click with comment
- revert version bump because workflow handles it

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a98824cb0832ea3b82e5a9a655405