### PR TITLE
Improve auto-click reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository hosts a Violent Monkey userscript that forwards project data fro
 3. Violent Monkey will automatically check this URL for updates when the `@version` changes.
 
 The script automatically forwards projects to Vertigram whenever you visit the Adekosiparis site or the Parasut invoice creation page. It stores a timestamp in a cookie so forwarding happens at most once every 30 minutes. A small status bar appears at the top of the page while the request is in progress.
+It also expands the order info field on Parasut invoices after the page fully loads so that the extra information field is visible automatically.
 
 ## Automatic version bump
 

--- a/forwarder.user.js
+++ b/forwarder.user.js
@@ -107,19 +107,25 @@
         if (!location.hostname.includes('uygulama.parasut.com')) {
             return;
         }
-        setTimeout(() => {
+
+        let attempts = 0;
+        const maxAttempts = 10;
+        const interval = setInterval(() => {
             const orderDiv = document.querySelector("div[class*='order-info']");
-            if (!orderDiv) {
-                return;
+            attempts++;
+            if (orderDiv) {
+                const clickable = orderDiv.querySelector('a, button, [role="button"], input[type="button"], input[type="submit"]');
+                (clickable || orderDiv).click();
+                clearInterval(interval);
+            } else if (attempts >= maxAttempts) {
+                clearInterval(interval);
             }
-            const clickable = orderDiv.querySelector('a, button, [role="button"], input[type="button"], input[type="submit"]');
-            (clickable || orderDiv).click();
-        }, 500);
+        }, 300);
     }
 
     // Run on page load
     maybeForward();
     attachLogoutHandler();
-    clickParasutOrderInfo();
+    window.addEventListener('load', clickParasutOrderInfo);
 })();
 


### PR DESCRIPTION
## Summary
- wait for `load` event before expanding order-info on Parasut invoices
- document automatic expansion in README

## Testing
- `node --check forwarder.user.js`

------
https://chatgpt.com/codex/tasks/task_e_685a9c7d4808832e8d776abf1deb2916