### PR TITLE
Improve order info handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository hosts a Violent Monkey userscript that forwards project data fro
 3. Violent Monkey will automatically check this URL for updates when the `@version` changes.
 
 The script automatically forwards projects to Vertigram whenever you visit the Adekosiparis site or the Parasut invoice creation page. It stores a timestamp in a cookie so forwarding happens at most once every 30 minutes. A small status bar appears at the top of the page while the request is in progress.
-It also expands the order info field on Parasut invoices after the page fully loads so that the extra information field is visible automatically.
+It also expands the order info field on Parasut invoices after the page fully loads so that the extra information field is visible automatically. If the page loads content asynchronously, the script keeps checking until it finds the "SİPARİŞ BİLGİSİ EKLE" button and clicks it.
 
 ## Automatic version bump
 

--- a/forwarder.user.js
+++ b/forwarder.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Adekosiparis → Vertigram Forwarder
 // @namespace    https://github.com/akina5525/adekoforwarder
-// @version      1.0.16
+// @version      1.0.17
 // @description  Automatically forwards projects to Vertigram API every 30 minutes
 // @match        https://adekosiparis.vanucci.com/*
 // @match        https://uygulama.parasut.com/*/satislar/yeni/fatura
@@ -108,14 +108,10 @@
             return;
         }
 
-        let attempts = 0;
-        const maxAttempts = 20;
         const interval = setInterval(() => {
             // Look for the localized button text first
             const addButton = Array.from(document.querySelectorAll('button, a, [role="button"]'))
                 .find(el => el.textContent.trim() === 'SİPARİŞ BİLGİSİ EKLE');
-
-            attempts++;
 
             if (addButton) {
                 addButton.click();
@@ -127,8 +123,6 @@
             if (orderDiv) {
                 const clickable = orderDiv.querySelector('a, button, [role="button"], input[type="button"], input[type="submit"]');
                 (clickable || orderDiv).click();
-                clearInterval(interval);
-            } else if (attempts >= maxAttempts) {
                 clearInterval(interval);
             }
         }, 300);


### PR DESCRIPTION
## Summary
- wait until `SİPARİŞ BİLGİSİ EKLE` button appears before trying to expand order info section
- document new behavior

## Testing
- `node --check forwarder.user.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685aa0a84e5c832e965ea2137c706e4b