### PR TITLE
Add logging for Parasut

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository hosts a Violent Monkey userscript that forwards project data fro
 
 The script automatically forwards projects to Vertigram whenever you visit the Adekosiparis site or the Parasut invoice creation page. It stores a timestamp in a cookie so forwarding happens at most once every 30 minutes. A small status bar appears at the top of the page while the request is in progress.
 It also expands the order info field on Parasut invoices after the page fully loads so that the extra information field is visible automatically. If the page loads content asynchronously, the script keeps checking until it finds the "SİPARİŞ BİLGİSİ EKLE" button and clicks it.
+The script now logs detailed diagnostics to the browser console when running on Parasut pages so issues can be debugged more easily.
 
 ## Automatic version bump
 


### PR DESCRIPTION
## Summary
- add a helper log function for Parasut pages
- log attempts to locate the order info button
- log when attaching and invoking the order number validator
- document logging in README

## Testing
- `node - <<'EOF'
const fs = require('fs');
const code = fs.readFileSync('forwarder.user.js','utf8');
try { new Function(code); console.log('Syntax ok'); }
catch(e) { console.error('Syntax error:', e); process.exit(1); }
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685b3b25b1bc832ea2742a768fe45266