### PR TITLE
Handle trinityDidTransition SPA event

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository hosts a Violent Monkey userscript that forwards project data fro
 3. Violent Monkey will automatically check this URL for updates when the `@version` changes.
 
 The script automatically forwards projects to Vertigram whenever you visit the Adekosiparis site or the Parasut invoice creation page. It stores a timestamp in a cookie so forwarding happens at most once every 30 minutes. A small status bar appears at the top of the page while the request is in progress.
-It also expands the order info field on Parasut invoices after the page fully loads so that the extra information field is visible automatically. If the page loads content asynchronously, the script keeps checking until it finds the "SİPARİŞ BİLGİSİ EKLE" button and clicks it. Because Parasut is a single-page application, the script watches for URL changes to reapply these enhancements whenever you navigate to the invoice creation page.
+It also expands the order info field on Parasut invoices after the page fully loads so that the extra information field is visible automatically. If the page loads content asynchronously, the script keeps checking until it finds the "SİPARİŞ BİLGİSİ EKLE" button and clicks it. Because Parasut is a single-page application, the script watches for URL changes and listens for the `trinityDidTransition` event to reapply these enhancements whenever you navigate to the invoice creation page.
 The script now logs detailed diagnostics to the browser console when running on Parasut pages so issues can be debugged more easily.
 
 ## Automatic version bump

--- a/forwarder.user.js
+++ b/forwarder.user.js
@@ -213,6 +213,10 @@
     if (isParasut) {
         let lastHref = location.href;
         runParasutEnhancements();
+        window.addEventListener('trinityDidTransition', () => {
+            logParasut('trinityDidTransition event received');
+            runParasutEnhancements();
+        });
         setInterval(() => {
             if (location.href !== lastHref) {
                 lastHref = location.href;


### PR DESCRIPTION
## Summary
- watch for `trinityDidTransition` to reapply enhancements when Parasut navigates inside its SPA
- document this SPA event behavior in the README

## Testing
- `node -c forwarder.user.js`

------
https://chatgpt.com/codex/tasks/task_e_685b422a516c832ea5406557511cf6cf