### PR TITLE
Fix Parasut dropdown interference

### DIFF
--- a/parasut-transition.user.js
+++ b/parasut-transition.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Parasut Page Load Alert
 // @namespace    https://github.com/akina5525/adekoforwarder
-// @version      1.14.0
+// @version      1.15.0
 // @description  Alerts whenever the Parasut SPA finishes loading a new page
 // @match        https://uygulama.parasut.com/*
 // @updateURL    https://raw.githubusercontent.com/akina5525/adekoforwarder/main/parasut-transition.user.js
@@ -34,8 +34,6 @@
         input = section.querySelector('input[type="text"]');
       }
       if (input) {
-        input.click();
-
         const updateBg = () => {
           const span = Array.from(document.querySelectorAll('span.prepend')).find(
             s => s.textContent.trim() === 'NO'


### PR DESCRIPTION
## Summary
- bump the Parasut userscript version to 1.15.0
- remove the automatic click on the invoice title input so dropdowns are not closed by repeated focus changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcaf57368832eb95facea973b7c8d